### PR TITLE
In messages, support diffing message field changes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -74,7 +74,7 @@
     - [ ] Message-level diffs
       - [x] Additions/removals
       - [x] Option changes
-      - [ ] Field changes
+      - [x] Field changes
       - [ ] Reserved changes
       - [ ] Nested enum changes
       - [ ] Nested message changes

--- a/src/proto_import.py
+++ b/src/proto_import.py
@@ -86,26 +86,26 @@ class ProtoImport(ProtoNode):
 
     @staticmethod
     def diff_sets(
-        left: list["ProtoImport"], right: list["ProtoImport"]
+        before: list["ProtoImport"], after: list["ProtoImport"]
     ) -> list["ProtoNodeDiff"]:
         diffs: list[ProtoNodeDiff] = []
-        left_names = set(i.path for i in left)
-        right_names = set(i.path for i in right)
-        for name in left_names - right_names:
-            diffs.append(ProtoImportAdded(next(i for i in left if i.path == name)))
-        for name in right_names - left_names:
-            diffs.append(ProtoImportRemoved(next(i for i in right if i.path == name)))
-        for name in left_names & right_names:
-            left_import = next(i for i in left if i.path == name)
-            right_import = next(i for i in right if i.path == name)
-            if left_import.weak and not right_import.weak:
-                diffs.append(ProtoImportMadeWeak(right_import))
-            if not left_import.weak and right_import.weak:
-                diffs.append(ProtoImportMadeNonWeak(right_import))
-            if left_import.public and not right_import.public:
-                diffs.append(ProtoImportMadePublic(right_import))
-            if not left_import.public and right_import.public:
-                diffs.append(ProtoImportMadeNonPublic(right_import))
+        before_names = set(i.path for i in before)
+        after_names = set(i.path for i in after)
+        for name in before_names - after_names:
+            diffs.append(ProtoImportRemoved(next(i for i in before if i.path == name)))
+        for name in after_names - before_names:
+            diffs.append(ProtoImportAdded(next(i for i in after if i.path == name)))
+        for name in before_names & after_names:
+            before_import = next(i for i in before if i.path == name)
+            after_import = next(i for i in after if i.path == name)
+            if before_import.weak and not after_import.weak:
+                diffs.append(ProtoImportMadeNonWeak(after_import))
+            elif not before_import.weak and after_import.weak:
+                diffs.append(ProtoImportMadeWeak(after_import))
+            if before_import.public and not after_import.public:
+                diffs.append(ProtoImportMadeNonPublic(after_import))
+            elif not before_import.public and after_import.public:
+                diffs.append(ProtoImportMadePublic(after_import))
 
         return diffs
 

--- a/src/proto_map.py
+++ b/src/proto_map.py
@@ -219,44 +219,44 @@ class ProtoMap(ProtoNode):
 
     @staticmethod
     def diff(
-        parent: Optional[ProtoNode], left: "ProtoMap", right: "ProtoMap"
+        parent: Optional[ProtoNode], before: "ProtoMap", after: "ProtoMap"
     ) -> list["ProtoNodeDiff"]:
-        if left is None and right is not None:
-            return [ProtoMapAdded(parent, right)]
-        elif left is not None and right is None:
-            return [ProtoMapRemoved(parent, left)]
-        elif left is None and right is None:
+        if before is None and after is not None:
+            return [ProtoMapAdded(parent, after)]
+        elif before is not None and after is None:
+            return [ProtoMapRemoved(parent, before)]
+        elif before is None and after is None:
             return []
-        elif left.name != right.name:
+        elif before.name != after.name:
             return []
-        elif left == right:
+        elif before == after:
             return []
         diffs: list["ProtoNodeDiff"] = []
         return diffs
 
     @staticmethod
     def diff_sets(
-        parent: Optional[ProtoNode], left: list["ProtoMap"], right: list["ProtoMap"]
+        parent: Optional[ProtoNode], before: list["ProtoMap"], after: list["ProtoMap"]
     ) -> Sequence["ProtoNodeDiff"]:
         diffs: list[ProtoNodeDiff] = []
-        left_names = set(o.name.identifier for o in left)
-        right_names = set(o.name.identifier for o in right)
-        for name in left_names - right_names:
-            diffs.append(
-                ProtoMapAdded(
-                    parent, next(i for i in left if i.name.identifier == name)
-                )
-            )
-        for name in right_names - left_names:
+        before_names = set(o.name.identifier for o in before)
+        after_names = set(o.name.identifier for o in after)
+        for name in before_names - after_names:
             diffs.append(
                 ProtoMapRemoved(
-                    parent, next(i for i in right if i.name.identifier == name)
+                    parent, next(i for i in before if i.name.identifier == name)
                 )
             )
-        for name in left_names & right_names:
-            left_enum = next(i for i in left if i.name.identifier == name)
-            right_enum = next(i for i in right if i.name.identifier == name)
-            diffs.extend(ProtoMap.diff(parent, left_enum, right_enum))
+        for name in after_names - before_names:
+            diffs.append(
+                ProtoMapAdded(
+                    parent, next(i for i in after if i.name.identifier == name)
+                )
+            )
+        for name in before_names & after_names:
+            before_enum = next(i for i in before if i.name.identifier == name)
+            after_enum = next(i for i in after if i.name.identifier == name)
+            diffs.extend(ProtoMap.diff(parent, before_enum, after_enum))
 
         return diffs
 

--- a/src/proto_message.py
+++ b/src/proto_message.py
@@ -160,6 +160,10 @@ class ProtoMessage(ProtoNode):
     def maps(self) -> list[ProtoMap]:
         return [node for node in self.nodes if isinstance(node, ProtoMap)]
 
+    @property
+    def message_fields(self) -> list[ProtoMessageField]:
+        return [node for node in self.nodes if isinstance(node, ProtoMessageField)]
+
     def serialize(self) -> str:
         serialize_parts = (
             [f"message {self.name.serialize()} {{"]
@@ -186,7 +190,11 @@ class ProtoMessage(ProtoNode):
         diffs.extend(ProtoOption.diff_sets(before.options, after.options))
         # diffs.extend(ProtoOneOf.diff_sets(before, before.oneofs, after.oneofs))
         diffs.extend(ProtoMap.diff_sets(before, before.maps, after.maps))
-        # diffs.extend(ProtoMessageField.diff_sets(before, before.message_fields, after.message_fields))
+        diffs.extend(
+            ProtoMessageField.diff_sets(
+                before, before.message_fields, after.message_fields
+            )
+        )
         return diffs
 
     @staticmethod

--- a/src/proto_message.py
+++ b/src/proto_message.py
@@ -169,43 +169,47 @@ class ProtoMessage(ProtoNode):
         return "\n".join(serialize_parts)
 
     @staticmethod
-    def diff(left: "ProtoMessage", right: "ProtoMessage") -> Sequence["ProtoNodeDiff"]:
-        if left is None and right is not None:
-            return [ProtoMessageAdded(right)]
-        elif left is not None and right is None:
-            return [ProtoMessageRemoved(left)]
-        elif left is None and right is None:
+    def diff(
+        before: "ProtoMessage", after: "ProtoMessage"
+    ) -> Sequence["ProtoNodeDiff"]:
+        if before is None and after is not None:
+            return [ProtoMessageAdded(after)]
+        elif before is not None and after is None:
+            return [ProtoMessageRemoved(before)]
+        elif before is None and after is None:
             return []
-        elif left.name != right.name:
+        elif before.name != after.name:
             return []
-        elif left == right:
+        elif before == after:
             return []
         diffs: list[ProtoNodeDiff] = []
-        diffs.extend(ProtoOption.diff_sets(left.options, right.options))
-        # diffs.extend(ProtoOneOf.diff_sets(left, left.oneofs, right.oneofs))
-        diffs.extend(ProtoMap.diff_sets(left, left.maps, right.maps))
-        # diffs.extend(ProtoMessageField.diff_sets(left, left.message_fields, right.message_fields))
+        diffs.extend(ProtoOption.diff_sets(before.options, after.options))
+        # diffs.extend(ProtoOneOf.diff_sets(before, before.oneofs, after.oneofs))
+        diffs.extend(ProtoMap.diff_sets(before, before.maps, after.maps))
+        # diffs.extend(ProtoMessageField.diff_sets(before, before.message_fields, after.message_fields))
         return diffs
 
     @staticmethod
     def diff_sets(
-        left: list["ProtoMessage"], right: list["ProtoMessage"]
+        before: list["ProtoMessage"], after: list["ProtoMessage"]
     ) -> Sequence["ProtoNodeDiff"]:
         diffs: list[ProtoNodeDiff] = []
-        left_names = set(o.name.identifier for o in left)
-        right_names = set(o.name.identifier for o in right)
-        for name in left_names - right_names:
+        before_names = set(o.name.identifier for o in before)
+        after_names = set(o.name.identifier for o in after)
+        for name in before_names - after_names:
             diffs.append(
-                ProtoMessageAdded(next(i for i in left if i.name.identifier == name))
+                ProtoMessageRemoved(
+                    next(i for i in before if i.name.identifier == name)
+                )
             )
-        for name in right_names - left_names:
+        for name in after_names - before_names:
             diffs.append(
-                ProtoMessageRemoved(next(i for i in right if i.name.identifier == name))
+                ProtoMessageAdded(next(i for i in after if i.name.identifier == name))
             )
-        for name in left_names & right_names:
-            left_enum = next(i for i in left if i.name.identifier == name)
-            right_enum = next(i for i in right if i.name.identifier == name)
-            diffs.extend(ProtoMessage.diff(left_enum, right_enum))
+        for name in before_names & after_names:
+            before_enum = next(i for i in before if i.name.identifier == name)
+            after_enum = next(i for i in after if i.name.identifier == name)
+            diffs.extend(ProtoMessage.diff(before_enum, after_enum))
 
         return diffs
 

--- a/src/proto_message_field.py
+++ b/src/proto_message_field.py
@@ -245,45 +245,49 @@ class ProtoMessageField(ProtoNode):
     @staticmethod
     def diff(
         parent: "ProtoNode",
-        left: Optional["ProtoMessageField"],
-        right: Optional["ProtoMessageField"],
+        before: Optional["ProtoMessageField"],
+        after: Optional["ProtoMessageField"],
     ) -> Sequence["ProtoNodeDiff"]:
         # TODO: scope these diffs under ProtoMessageField
         diffs: list["ProtoNodeDiff"] = []
-        if left is None or right is None:
-            if right is not None:
-                diffs.append(ProtoMessageFieldAdded(parent, right))
-            elif left is not None:
-                diffs.append(ProtoMessageFieldRemoved(parent, left))
+        if before is None or after is None:
+            if after is not None:
+                diffs.append(ProtoMessageFieldAdded(parent, after))
+            elif before is not None:
+                diffs.append(ProtoMessageFieldRemoved(parent, before))
         else:
-            if left.name != right.name:
-                diffs.append(ProtoMessageFieldNameChanged(parent, right, left.name))
-            if left.number != right.number:
+            if before.name != after.name:
+                diffs.append(ProtoMessageFieldNameChanged(parent, before, after.name))
+            if before.number != after.number:
                 raise ValueError(
-                    f"Don't know how to handle diff between message fields whose names are identical: {left}, {right}"
+                    f"Don't know how to handle diff between message fields whose names are identical: {before}, {after}"
                 )
-            diffs.extend(ProtoMessageFieldOption.diff_sets(left.options, right.options))
+            diffs.extend(
+                ProtoMessageFieldOption.diff_sets(before.options, after.options)
+            )
         return diffs
 
     @staticmethod
     def diff_sets(
         parent: "ProtoNode",
-        left: list["ProtoMessageField"],
-        right: list["ProtoMessageField"],
+        before: list["ProtoMessageField"],
+        after: list["ProtoMessageField"],
     ) -> list["ProtoNodeDiff"]:
         diffs: list[ProtoNodeDiff] = []
 
-        left_number_to_fields = {int(mf.number): mf for mf in left}
-        right_number_to_fields = {int(mf.number): mf for mf in right}
+        before_number_to_fields = {int(mf.number): mf for mf in before}
+        after_number_to_fields = {int(mf.number): mf for mf in after}
         all_numbers = sorted(
-            set(left_number_to_fields.keys()).union(set(right_number_to_fields.keys()))
+            set(before_number_to_fields.keys()).union(
+                set(after_number_to_fields.keys())
+            )
         )
         for number in all_numbers:
             diffs.extend(
                 ProtoMessageField.diff(
                     parent,
-                    left_number_to_fields.get(number, None),
-                    right_number_to_fields.get(number, None),
+                    before_number_to_fields.get(number, None),
+                    after_number_to_fields.get(number, None),
                 )
             )
 

--- a/src/proto_message_field.py
+++ b/src/proto_message_field.py
@@ -339,21 +339,3 @@ class ProtoMessageFieldNameChanged(ProtoMessageFieldDiff):
 
     def __str__(self) -> str:
         return f"<ProtoMessageFieldNameChanged message={self.message} message_field={self.message_field} new_name={self.new_name}>"
-
-
-class ProtoMessageFieldValueChanged(ProtoMessageFieldDiff):
-    def __init__(
-        self, message: ProtoNode, message_field: ProtoMessageField, new_value: ProtoInt
-    ):
-        super().__init__(message, message_field)
-        self.new_value = new_value
-
-    def __eq__(self, other: object) -> bool:
-        return (
-            super().__eq__(other)
-            and isinstance(other, ProtoMessageFieldValueChanged)
-            and self.new_value == other.new_value
-        )
-
-    def __str__(self) -> str:
-        return f"<ProtoMessageFieldValueChanged message={self.message} message_field={self.message_field} new_value={self.new_value}>"

--- a/src/proto_message_field.py
+++ b/src/proto_message_field.py
@@ -248,23 +248,22 @@ class ProtoMessageField(ProtoNode):
         left: Optional["ProtoMessageField"],
         right: Optional["ProtoMessageField"],
     ) -> Sequence["ProtoNodeDiff"]:
+        # TODO: scope these diffs under ProtoMessageField
+        diffs: list["ProtoNodeDiff"] = []
         if left is None or right is None:
             if right is not None:
-                return [ProtoMessageFieldAdded(parent, right)]
+                diffs.append(ProtoMessageFieldAdded(parent, right))
             elif left is not None:
-                return [ProtoMessageFieldRemoved(parent, left)]
-            else:
-                return []
+                diffs.append(ProtoMessageFieldRemoved(parent, left))
         else:
+            if left.name != right.name:
+                diffs.append(ProtoMessageFieldNameChanged(parent, right, left.name))
             if left.number != right.number:
-                return []
-            elif left == right:
-                return []
-            diffs: list["ProtoNodeDiff"] = []
-            # TODO: scope these diffs under ProtoMessageField
+                raise ValueError(
+                    f"Don't know how to handle diff between message fields whose names are identical: {left}, {right}"
+                )
             diffs.extend(ProtoMessageFieldOption.diff_sets(left.options, right.options))
-            diffs.append(ProtoMessageFieldValueChanged(parent, right, left.number))
-            return diffs
+        return diffs
 
     @staticmethod
     def diff_sets(

--- a/src/proto_package.py
+++ b/src/proto_package.py
@@ -54,43 +54,43 @@ class ProtoPackage(ProtoNode):
 
     @staticmethod
     def diff(
-        left: Optional["ProtoPackage"], right: Optional["ProtoPackage"]
+        before: Optional["ProtoPackage"], after: Optional["ProtoPackage"]
     ) -> list["ProtoNodeDiff"]:
-        if left == right:
+        if before == after:
             return []
-        elif left is not None and right is None:
-            return [ProtoPackageAdded(left)]
-        elif left is None and right is not None:
-            return [ProtoPackageRemoved(right)]
+        elif before is not None and after is None:
+            return [ProtoPackageRemoved(before)]
+        elif before is None and after is not None:
+            return [ProtoPackageAdded(after)]
 
-        assert left is not None and right is not None
-        return [ProtoPackageChanged(left, right)]
+        assert before is not None and after is not None
+        return [ProtoPackageChanged(before, after)]
 
 
 class ProtoPackageChanged(ProtoNodeDiff):
-    def __init__(self, left: ProtoPackage, right: ProtoPackage):
-        self.left = left
-        self.right = right
+    def __init__(self, before: ProtoPackage, after: ProtoPackage):
+        self.before = before
+        self.after = after
 
     def __eq__(self, other: object) -> bool:
         return (
             isinstance(other, ProtoPackageChanged)
-            and self.left == other.left
-            and self.right == other.right
+            and self.before == other.before
+            and self.after == other.after
         )
 
 
 class ProtoPackageAdded(ProtoNodeDiff):
-    def __init__(self, left: ProtoPackage):
-        self.left = left
+    def __init__(self, after: ProtoPackage):
+        self.after = after
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, ProtoPackageAdded) and self.left == other.left
+        return isinstance(other, ProtoPackageAdded) and self.after == other.after
 
 
 class ProtoPackageRemoved(ProtoNodeDiff):
-    def __init__(self, right: ProtoPackage):
-        self.right = right
+    def __init__(self, before: ProtoPackage):
+        self.before = before
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, ProtoPackageRemoved) and self.right == other.right
+        return isinstance(other, ProtoPackageRemoved) and self.before == other.before

--- a/src/proto_syntax.py
+++ b/src/proto_syntax.py
@@ -63,20 +63,20 @@ class ProtoSyntax(ProtoNode):
         return f"syntax = {self.syntax.serialize()};"
 
     @staticmethod
-    def diff(left: "ProtoSyntax", right: "ProtoSyntax") -> list["ProtoNodeDiff"]:
-        if left == right:
+    def diff(before: "ProtoSyntax", after: "ProtoSyntax") -> list["ProtoNodeDiff"]:
+        if before == after:
             return []
-        return [ProtoSyntaxChanged(left, right)]
+        return [ProtoSyntaxChanged(before, after)]
 
 
 class ProtoSyntaxChanged(ProtoNodeDiff):
-    def __init__(self, left: ProtoSyntax, right: ProtoSyntax):
-        self.left = left
-        self.right = right
+    def __init__(self, before: ProtoSyntax, after: ProtoSyntax):
+        self.before = before
+        self.after = after
 
     def __eq__(self, other: object) -> bool:
         return (
             isinstance(other, ProtoSyntaxChanged)
-            and self.left == other.left
-            and self.right == other.right
+            and self.before == other.before
+            and self.after == other.after
         )

--- a/src/util/compatibility_checker.py
+++ b/src/util/compatibility_checker.py
@@ -12,8 +12,8 @@ from src.util.parser import Parser
 class CompatibilityChecker:
     allowed_diff_types: list[Type[ProtoNodeDiff]]
 
-    def check_compatibility(self, left: ProtoFile, right: ProtoFile):
-        for diff in left.diff(right):
+    def check_compatibility(self, before: ProtoFile, after: ProtoFile):
+        for diff in before.diff(after):
             if diff.__class__ in self.allowed_diff_types:
                 continue
             yield diff
@@ -21,13 +21,13 @@ class CompatibilityChecker:
 
 def main() -> int:
     with open(sys.argv[1], "r") as proto_file:
-        left = Parser.loads(proto_file.read())
+        before = Parser.loads(proto_file.read())
 
     with open(sys.argv[2], "r") as proto_file:
-        right = Parser.loads(proto_file.read())
+        after = Parser.loads(proto_file.read())
 
     violations = list(
-        CompatibilityChecker([ProtoMessageAdded]).check_compatibility(left, right)
+        CompatibilityChecker([ProtoMessageAdded]).check_compatibility(before, after)
     )
     if violations:
         print(f"Violations: {violations}")

--- a/test/proto_enum_test.py
+++ b/test/proto_enum_test.py
@@ -9,9 +9,10 @@ from src.proto_enum import (
     ProtoEnumAdded,
     ProtoEnumRemoved,
     ProtoEnumValue,
+    ProtoEnumValueAdded,
     ProtoEnumValueNameChanged,
     ProtoEnumValueOption,
-    ProtoEnumValueValueChanged,
+    ProtoEnumValueRemoved,
 )
 from src.proto_identifier import ProtoIdentifier
 from src.proto_int import ProtoInt, ProtoIntSign
@@ -413,7 +414,6 @@ class EnumTest(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            ProtoEnum.diff(pe1, pe2),
             [
                 ProtoEnumValueNameChanged(
                     pe1,
@@ -421,6 +421,7 @@ class EnumTest(unittest.TestCase):
                     ProtoIdentifier(None, "ME_UNKNOWN"),
                 )
             ],
+            ProtoEnum.diff(pe1, pe2),
         )
 
     def test_diff_different_enum_value_value_returns_enum_diff(self):
@@ -450,14 +451,20 @@ class EnumTest(unittest.TestCase):
         diff = ProtoEnum.diff(pe1, pe2)
 
         self.assertIn(
-            ProtoEnumValueValueChanged(
+            ProtoEnumValueRemoved(
                 pe1,
-                pe2.values[0],
-                ProtoInt(None, 0, ProtoIntSign.POSITIVE),
+                pe1.values[0],
             ),
             diff,
         )
-        self.assertEqual(1, len(diff))
+        self.assertIn(
+            ProtoEnumValueAdded(
+                pe1,
+                pe2.values[0],
+            ),
+            diff,
+        )
+        self.assertEqual(2, len(diff))
 
     def test_diff_enum_added(self):
         pe1 = None

--- a/test/proto_enum_test.py
+++ b/test/proto_enum_test.py
@@ -417,8 +417,8 @@ class EnumTest(unittest.TestCase):
             [
                 ProtoEnumValueNameChanged(
                     pe1,
-                    pe2.nodes[0],
-                    ProtoIdentifier(None, "ME_UNKNOWN"),
+                    pe1.nodes[0],
+                    ProtoIdentifier(None, "ME_KNOWN"),
                 )
             ],
             ProtoEnum.diff(pe1, pe2),
@@ -1006,39 +1006,6 @@ class EnumTest(unittest.TestCase):
             ProtoEnumRemoved(
                 ProtoEnum(
                     None,
-                    ProtoIdentifier(None, "FooEnum2"),
-                    [
-                        ProtoEnumValue(
-                            None,
-                            ProtoIdentifier(None, "FE_UNKNOWN2"),
-                            ProtoInt(None, 0, ProtoIntSign.POSITIVE),
-                        )
-                    ],
-                ),
-            ),
-            diff,
-        )
-
-        self.assertIn(
-            ProtoEnumRemoved(
-                ProtoEnum(
-                    None,
-                    ProtoIdentifier(None, "TagEnum2"),
-                    [
-                        ProtoEnumValue(
-                            None,
-                            ProtoIdentifier(None, "TE_UNKNOWN2"),
-                            ProtoInt(None, 0, ProtoIntSign.POSITIVE),
-                        )
-                    ],
-                ),
-            ),
-            diff,
-        )
-        self.assertIn(
-            ProtoEnumAdded(
-                ProtoEnum(
-                    None,
                     ProtoIdentifier(None, "FooEnum"),
                     [
                         ProtoEnumValue(
@@ -1051,8 +1018,9 @@ class EnumTest(unittest.TestCase):
             ),
             diff,
         )
+
         self.assertIn(
-            ProtoEnumAdded(
+            ProtoEnumRemoved(
                 ProtoEnum(
                     None,
                     ProtoIdentifier(None, "TagEnum"),
@@ -1060,6 +1028,38 @@ class EnumTest(unittest.TestCase):
                         ProtoEnumValue(
                             None,
                             ProtoIdentifier(None, "TE_UNKNOWN"),
+                            ProtoInt(None, 0, ProtoIntSign.POSITIVE),
+                        )
+                    ],
+                ),
+            ),
+            diff,
+        )
+        self.assertIn(
+            ProtoEnumAdded(
+                ProtoEnum(
+                    None,
+                    ProtoIdentifier(None, "FooEnum2"),
+                    [
+                        ProtoEnumValue(
+                            None,
+                            ProtoIdentifier(None, "FE_UNKNOWN2"),
+                            ProtoInt(None, 0, ProtoIntSign.POSITIVE),
+                        )
+                    ],
+                ),
+            ),
+            diff,
+        )
+        self.assertIn(
+            ProtoEnumAdded(
+                ProtoEnum(
+                    None,
+                    ProtoIdentifier(None, "TagEnum2"),
+                    [
+                        ProtoEnumValue(
+                            None,
+                            ProtoIdentifier(None, "TE_UNKNOWN2"),
                             ProtoInt(None, 0, ProtoIntSign.POSITIVE),
                         )
                     ],
@@ -1082,10 +1082,10 @@ class EnumTest(unittest.TestCase):
                 ),
                 ProtoEnumValue(
                     None,
-                    ProtoIdentifier(None, "BE_UNKNOWN2"),
+                    ProtoIdentifier(None, "BE_UNKNOWN"),
                     ProtoInt(None, 0, ProtoIntSign.POSITIVE),
                 ),
-                ProtoIdentifier(None, "BE_UNKNOWN"),
+                ProtoIdentifier(None, "BE_UNKNOWN2"),
             ),
             diff,
         )

--- a/test/proto_message_field_test.py
+++ b/test/proto_message_field_test.py
@@ -166,8 +166,8 @@ class MessageFieldTest(unittest.TestCase):
             [
                 ProtoMessageFieldNameChanged(
                     None,
-                    pmf2,
-                    pmf1.name,
+                    pmf1,
+                    pmf2.name,
                 )
             ],
             ProtoMessageField.diff(None, pmf1, pmf2),

--- a/test/proto_message_field_test.py
+++ b/test/proto_message_field_test.py
@@ -6,7 +6,12 @@ from src.proto_identifier import (
     ProtoIdentifier,
 )
 from src.proto_int import ProtoInt, ProtoIntSign
-from src.proto_message_field import ProtoMessageField, ProtoMessageFieldTypesEnum
+from src.proto_message_field import (
+    ProtoMessageField,
+    ProtoMessageFieldAdded,
+    ProtoMessageFieldRemoved,
+    ProtoMessageFieldTypesEnum,
+)
 
 
 class MessageFieldTest(unittest.TestCase):
@@ -127,3 +132,322 @@ class MessageFieldTest(unittest.TestCase):
                 ProtoEnumOrMessageIdentifier(None, ".google.proto.FooType"),
             ),
         )
+
+    def test_diff_same_field_returns_empty(self):
+        pmf1 = ProtoMessageField(
+            None,
+            ProtoMessageFieldTypesEnum.FLOAT,
+            ProtoIdentifier(None, "my_message_field"),
+            ProtoInt(None, 10, ProtoIntSign.POSITIVE),
+        )
+        pmf2 = ProtoMessageField(
+            None,
+            ProtoMessageFieldTypesEnum.FLOAT,
+            ProtoIdentifier(None, "my_message_field"),
+            ProtoInt(None, 10, ProtoIntSign.POSITIVE),
+        )
+        self.assertEqual(ProtoMessageField.diff(pmf1, pmf2), [])
+
+    def test_diff_different_number_name_returns_empty(self):
+        pmf1 = ProtoMessageField(
+            None,
+            ProtoMessageFieldTypesEnum.FLOAT,
+            ProtoIdentifier(None, "foo"),
+            ProtoInt(None, 10, ProtoIntSign.POSITIVE),
+        )
+        pmf2 = ProtoMessageField(
+            None,
+            ProtoMessageFieldTypesEnum.FLOAT,
+            ProtoIdentifier(None, "bar"),
+            ProtoInt(None, 11, ProtoIntSign.POSITIVE),
+        )
+        self.assertEqual(ProtoMessageField.diff(pmf1, pmf2), [])
+
+    def test_diff_different_field_name_same_number_returns_field_diff(self):
+        pmf1 = ProtoMessageField(
+            None,
+            ProtoMessageFieldTypesEnum.FLOAT,
+            ProtoIdentifier(None, "foo"),
+            ProtoInt(None, 10, ProtoIntSign.POSITIVE),
+        )
+        pmf2 = ProtoMessageField(
+            None,
+            ProtoMessageFieldTypesEnum.FLOAT,
+            ProtoIdentifier(None, "bar"),
+            ProtoInt(None, 10, ProtoIntSign.POSITIVE),
+        )
+        self.assertEqual(
+            ProtoMessageField.diff(pmf1, pmf2),
+            [
+                ProtoMessageFieldNameChanged(
+                    pmf1,
+                    pmf2.name,
+                )
+            ],
+        )
+
+    def test_diff_different_field_number_same_name_returns_field_diff(self):
+        pmf1 = ProtoMessageField(
+            None,
+            ProtoMessageFieldTypesEnum.FLOAT,
+            ProtoIdentifier(None, "foo"),
+            ProtoInt(None, 10, ProtoIntSign.POSITIVE),
+        )
+        pmf2 = ProtoMessageField(
+            None,
+            ProtoMessageFieldTypesEnum.FLOAT,
+            ProtoIdentifier(None, "foo"),
+            ProtoInt(None, 11, ProtoIntSign.POSITIVE),
+        )
+
+        diff = ProtoMessageField.diff(pmf1, pmf2)
+
+        self.assertEqual(
+            [
+                ProtoMessageFieldNumberChanged(pmf1, pmf2.number),
+            ],
+            diff,
+        )
+
+    def test_diff_field_added(self):
+        pmf1 = None
+        pmf2 = ProtoMessageField(
+            None,
+            ProtoMessageFieldTypesEnum.FLOAT,
+            ProtoIdentifier(None, "foo"),
+            ProtoInt(None, 11, ProtoIntSign.POSITIVE),
+        )
+        self.assertEqual(
+            [
+                ProtoMessageFieldAdded(pmf2),
+            ],
+            ProtoMessageField.diff(pmf1, pmf2),
+        )
+
+    def test_diff_field_removed(self):
+        pmf1 = ProtoMessageField(
+            None,
+            ProtoMessageFieldTypesEnum.FLOAT,
+            ProtoIdentifier(None, "foo"),
+            ProtoInt(None, 10, ProtoIntSign.POSITIVE),
+        )
+        pmf2 = None
+        self.assertEqual(
+            [
+                ProtoMessageFieldRemoved(pmf1),
+            ],
+            ProtoMessageField.diff(pmf1, pmf2),
+        )
+
+    def test_diff_sets_empty_returns_empty(self):
+        set1 = []
+        set2 = []
+        self.assertEqual(ProtoMessageField.diff_sets(set1, set2), [])
+
+    def test_diff_sets_no_change(self):
+        set1 = [
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "foo"),
+                ProtoInt(None, 1, ProtoIntSign.POSITIVE),
+            ),
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "bar"),
+                ProtoInt(None, 2, ProtoIntSign.POSITIVE),
+            ),
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "baz"),
+                ProtoInt(None, 3, ProtoIntSign.POSITIVE),
+            ),
+        ]
+        self.assertEqual([], ProtoMessageField.diff_sets(set1, set1))
+
+    def test_diff_sets_all_removed(self):
+        set1 = []
+        set2 = [
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "foo"),
+                ProtoInt(None, 1, ProtoIntSign.POSITIVE),
+            ),
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "bar"),
+                ProtoInt(None, 2, ProtoIntSign.POSITIVE),
+            ),
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "baz"),
+                ProtoInt(None, 3, ProtoIntSign.POSITIVE),
+            ),
+        ]
+        diff = ProtoMessageField.diff_sets(set1, set2)
+
+        for pmf in set2:
+            self.assertIn(
+                ProtoMessageFieldRemoved(pmf),
+                diff,
+            )
+        self.assertEqual(3, len(diff))
+
+    def test_diff_sets_all_added(self):
+        set1 = [
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "foo"),
+                ProtoInt(None, 1, ProtoIntSign.POSITIVE),
+            ),
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "bar"),
+                ProtoInt(None, 2, ProtoIntSign.POSITIVE),
+            ),
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "baz"),
+                ProtoInt(None, 3, ProtoIntSign.POSITIVE),
+            ),
+        ]
+        set2 = []
+        diff = ProtoMessageField.diff_sets(set1, set2)
+
+        for pmf in set1:
+            self.assertIn(
+                ProtoMessageFieldAdded(pmf),
+                diff,
+            )
+
+        self.assertEqual(3, len(diff))
+
+    def test_diff_sets_mutually_exclusive(self):
+        set1 = [
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "foo"),
+                ProtoInt(None, 1, ProtoIntSign.POSITIVE),
+            ),
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "bar"),
+                ProtoInt(None, 2, ProtoIntSign.POSITIVE),
+            ),
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "baz"),
+                ProtoInt(None, 3, ProtoIntSign.POSITIVE),
+            ),
+        ]
+        set2 = [
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "foo2"),
+                ProtoInt(None, 4, ProtoIntSign.POSITIVE),
+            ),
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "bar2"),
+                ProtoInt(None, 5, ProtoIntSign.POSITIVE),
+            ),
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "baz2"),
+                ProtoInt(None, 6, ProtoIntSign.POSITIVE),
+            ),
+        ]
+
+        diff = ProtoMessageField.diff_sets(set1, set2)
+
+        for pmf in set1:
+            self.assertIn(
+                ProtoMessageFieldAdded(pmf),
+                diff,
+            )
+
+        for pmf in set2:
+            self.assertIn(
+                ProtoMessageFieldRemoved(pmf),
+                diff,
+            )
+
+        self.assertEqual(6, len(diff))
+
+    def test_diff_sets_overlap(self):
+        set1 = [
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "foo"),
+                ProtoInt(None, 1, ProtoIntSign.POSITIVE),
+            ),
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "bar"),
+                ProtoInt(None, 2, ProtoIntSign.POSITIVE),
+            ),
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "baz"),
+                ProtoInt(None, 3, ProtoIntSign.POSITIVE),
+            ),
+        ]
+        set2 = [
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "foo2"),
+                ProtoInt(None, 4, ProtoIntSign.POSITIVE),
+            ),
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "bar"),
+                ProtoInt(None, 2, ProtoIntSign.POSITIVE),
+            ),
+            ProtoMessageField(
+                None,
+                ProtoMessageFieldTypesEnum.FLOAT,
+                ProtoIdentifier(None, "baz2"),
+                ProtoInt(None, 6, ProtoIntSign.POSITIVE),
+            ),
+        ]
+
+        diff = ProtoMessageField.diff_sets(set1, set2)
+
+        self.assertIn(
+            ProtoMessageFieldRemoved(set1[0]),
+            diff,
+        )
+
+        self.assertIn(
+            ProtoMessageFieldRemoved(set1[2]),
+            diff,
+        )
+        self.assertIn(
+            ProtoMessageFieldAdded(set2[0]),
+            diff,
+        )
+        self.assertIn(
+            ProtoMessageFieldAdded(set2[2]),
+            diff,
+        )
+
+        self.assertEqual(5, len(diff))

--- a/test/proto_message_field_test.py
+++ b/test/proto_message_field_test.py
@@ -9,6 +9,7 @@ from src.proto_int import ProtoInt, ProtoIntSign
 from src.proto_message_field import (
     ProtoMessageField,
     ProtoMessageFieldAdded,
+    ProtoMessageFieldNameChanged,
     ProtoMessageFieldRemoved,
     ProtoMessageFieldTypesEnum,
 )
@@ -78,7 +79,7 @@ class MessageFieldTest(unittest.TestCase):
             parsed_double_undescored_field.node,
             ProtoMessageField(
                 None,
-                ProtoMessageFieldTypesEnum.STRING,
+                ProtoMessageFieldTypesEnum.BOOL,
                 ProtoIdentifier(None, "__test_field"),
                 ProtoInt(None, 1, ProtoIntSign.POSITIVE),
             ),
@@ -146,22 +147,7 @@ class MessageFieldTest(unittest.TestCase):
             ProtoIdentifier(None, "my_message_field"),
             ProtoInt(None, 10, ProtoIntSign.POSITIVE),
         )
-        self.assertEqual(ProtoMessageField.diff(pmf1, pmf2), [])
-
-    def test_diff_different_number_name_returns_empty(self):
-        pmf1 = ProtoMessageField(
-            None,
-            ProtoMessageFieldTypesEnum.FLOAT,
-            ProtoIdentifier(None, "foo"),
-            ProtoInt(None, 10, ProtoIntSign.POSITIVE),
-        )
-        pmf2 = ProtoMessageField(
-            None,
-            ProtoMessageFieldTypesEnum.FLOAT,
-            ProtoIdentifier(None, "bar"),
-            ProtoInt(None, 11, ProtoIntSign.POSITIVE),
-        )
-        self.assertEqual(ProtoMessageField.diff(pmf1, pmf2), [])
+        self.assertEqual(ProtoMessageField.diff(None, pmf1, pmf2), [])
 
     def test_diff_different_field_name_same_number_returns_field_diff(self):
         pmf1 = ProtoMessageField(
@@ -177,51 +163,14 @@ class MessageFieldTest(unittest.TestCase):
             ProtoInt(None, 10, ProtoIntSign.POSITIVE),
         )
         self.assertEqual(
-            ProtoMessageField.diff(pmf1, pmf2),
             [
                 ProtoMessageFieldNameChanged(
-                    pmf1,
-                    pmf2.name,
+                    None,
+                    pmf2,
+                    pmf1.name,
                 )
             ],
-        )
-
-    def test_diff_different_field_number_same_name_returns_field_diff(self):
-        pmf1 = ProtoMessageField(
-            None,
-            ProtoMessageFieldTypesEnum.FLOAT,
-            ProtoIdentifier(None, "foo"),
-            ProtoInt(None, 10, ProtoIntSign.POSITIVE),
-        )
-        pmf2 = ProtoMessageField(
-            None,
-            ProtoMessageFieldTypesEnum.FLOAT,
-            ProtoIdentifier(None, "foo"),
-            ProtoInt(None, 11, ProtoIntSign.POSITIVE),
-        )
-
-        diff = ProtoMessageField.diff(pmf1, pmf2)
-
-        self.assertEqual(
-            [
-                ProtoMessageFieldNumberChanged(pmf1, pmf2.number),
-            ],
-            diff,
-        )
-
-    def test_diff_field_added(self):
-        pmf1 = None
-        pmf2 = ProtoMessageField(
-            None,
-            ProtoMessageFieldTypesEnum.FLOAT,
-            ProtoIdentifier(None, "foo"),
-            ProtoInt(None, 11, ProtoIntSign.POSITIVE),
-        )
-        self.assertEqual(
-            [
-                ProtoMessageFieldAdded(pmf2),
-            ],
-            ProtoMessageField.diff(pmf1, pmf2),
+            ProtoMessageField.diff(None, pmf1, pmf2),
         )
 
     def test_diff_field_removed(self):
@@ -234,15 +183,15 @@ class MessageFieldTest(unittest.TestCase):
         pmf2 = None
         self.assertEqual(
             [
-                ProtoMessageFieldRemoved(pmf1),
+                ProtoMessageFieldRemoved(None, pmf1),
             ],
-            ProtoMessageField.diff(pmf1, pmf2),
+            ProtoMessageField.diff(None, pmf1, pmf2),
         )
 
     def test_diff_sets_empty_returns_empty(self):
         set1 = []
         set2 = []
-        self.assertEqual(ProtoMessageField.diff_sets(set1, set2), [])
+        self.assertEqual(ProtoMessageField.diff_sets(None, set1, set2), [])
 
     def test_diff_sets_no_change(self):
         set1 = [
@@ -265,7 +214,7 @@ class MessageFieldTest(unittest.TestCase):
                 ProtoInt(None, 3, ProtoIntSign.POSITIVE),
             ),
         ]
-        self.assertEqual([], ProtoMessageField.diff_sets(set1, set1))
+        self.assertEqual([], ProtoMessageField.diff_sets(None, set1, set1))
 
     def test_diff_sets_all_removed(self):
         set1 = []
@@ -289,11 +238,11 @@ class MessageFieldTest(unittest.TestCase):
                 ProtoInt(None, 3, ProtoIntSign.POSITIVE),
             ),
         ]
-        diff = ProtoMessageField.diff_sets(set1, set2)
+        diff = ProtoMessageField.diff_sets(None, set1, set2)
 
         for pmf in set2:
             self.assertIn(
-                ProtoMessageFieldRemoved(pmf),
+                ProtoMessageFieldRemoved(None, pmf),
                 diff,
             )
         self.assertEqual(3, len(diff))
@@ -320,11 +269,11 @@ class MessageFieldTest(unittest.TestCase):
             ),
         ]
         set2 = []
-        diff = ProtoMessageField.diff_sets(set1, set2)
+        diff = ProtoMessageField.diff_sets(None, set1, set2)
 
         for pmf in set1:
             self.assertIn(
-                ProtoMessageFieldAdded(pmf),
+                ProtoMessageFieldAdded(None, pmf),
                 diff,
             )
 
@@ -372,17 +321,17 @@ class MessageFieldTest(unittest.TestCase):
             ),
         ]
 
-        diff = ProtoMessageField.diff_sets(set1, set2)
+        diff = ProtoMessageField.diff_sets(None, set1, set2)
 
         for pmf in set1:
             self.assertIn(
-                ProtoMessageFieldAdded(pmf),
+                ProtoMessageFieldAdded(None, pmf),
                 diff,
             )
 
         for pmf in set2:
             self.assertIn(
-                ProtoMessageFieldRemoved(pmf),
+                ProtoMessageFieldRemoved(None, pmf),
                 diff,
             )
 
@@ -430,24 +379,24 @@ class MessageFieldTest(unittest.TestCase):
             ),
         ]
 
-        diff = ProtoMessageField.diff_sets(set1, set2)
+        diff = ProtoMessageField.diff_sets(None, set1, set2)
 
         self.assertIn(
-            ProtoMessageFieldRemoved(set1[0]),
-            diff,
-        )
-
-        self.assertIn(
-            ProtoMessageFieldRemoved(set1[2]),
-            diff,
-        )
-        self.assertIn(
-            ProtoMessageFieldAdded(set2[0]),
-            diff,
-        )
-        self.assertIn(
-            ProtoMessageFieldAdded(set2[2]),
+            ProtoMessageFieldRemoved(None, set1[0]),
             diff,
         )
 
-        self.assertEqual(5, len(diff))
+        self.assertIn(
+            ProtoMessageFieldRemoved(None, set1[2]),
+            diff,
+        )
+        self.assertIn(
+            ProtoMessageFieldAdded(None, set2[0]),
+            diff,
+        )
+        self.assertIn(
+            ProtoMessageFieldAdded(None, set2[2]),
+            diff,
+        )
+
+        self.assertEqual(4, len(diff))

--- a/test/proto_message_test.py
+++ b/test/proto_message_test.py
@@ -941,12 +941,12 @@ class MessageTest(unittest.TestCase):
         self.assertEqual(ProtoMessage.diff_sets(set1, set1), [])
 
     def test_diff_sets_all_removed(self):
-        set1 = []
-        set2 = [
+        set1 = [
             ProtoMessage(None, ProtoIdentifier(None, "FooMessage"), []),
             ProtoMessage(None, ProtoIdentifier(None, "BarMessage"), []),
             ProtoMessage(None, ProtoIdentifier(None, "BazMessage"), []),
         ]
+        set2 = []
         diff = ProtoMessage.diff_sets(set1, set2)
         self.assertIn(
             ProtoMessageRemoved(
@@ -969,12 +969,12 @@ class MessageTest(unittest.TestCase):
         self.assertEqual(3, len(diff))
 
     def test_diff_sets_all_added(self):
-        set1 = [
+        set1 = []
+        set2 = [
             ProtoMessage(None, ProtoIdentifier(None, "FooMessage"), []),
             ProtoMessage(None, ProtoIdentifier(None, "BarMessage"), []),
             ProtoMessage(None, ProtoIdentifier(None, "BazMessage"), []),
         ]
-        set2 = []
 
         diff = ProtoMessage.diff_sets(set1, set2)
         self.assertIn(
@@ -1011,37 +1011,37 @@ class MessageTest(unittest.TestCase):
         diff = ProtoMessage.diff_sets(set1, set2)
         self.assertIn(
             ProtoMessageAdded(
-                ProtoMessage(None, ProtoIdentifier(None, "FooMessage"), [])
-            ),
-            diff,
-        )
-        self.assertIn(
-            ProtoMessageAdded(
-                ProtoMessage(None, ProtoIdentifier(None, "BarMessage"), [])
-            ),
-            diff,
-        )
-        self.assertIn(
-            ProtoMessageAdded(
-                ProtoMessage(None, ProtoIdentifier(None, "BazMessage"), [])
-            ),
-            diff,
-        )
-        self.assertIn(
-            ProtoMessageRemoved(
                 ProtoMessage(None, ProtoIdentifier(None, "FooMessage2"), [])
             ),
             diff,
         )
         self.assertIn(
-            ProtoMessageRemoved(
+            ProtoMessageAdded(
                 ProtoMessage(None, ProtoIdentifier(None, "BarMessage2"), [])
             ),
             diff,
         )
         self.assertIn(
-            ProtoMessageRemoved(
+            ProtoMessageAdded(
                 ProtoMessage(None, ProtoIdentifier(None, "BazMessage2"), [])
+            ),
+            diff,
+        )
+        self.assertIn(
+            ProtoMessageRemoved(
+                ProtoMessage(None, ProtoIdentifier(None, "FooMessage"), [])
+            ),
+            diff,
+        )
+        self.assertIn(
+            ProtoMessageRemoved(
+                ProtoMessage(None, ProtoIdentifier(None, "BarMessage"), [])
+            ),
+            diff,
+        )
+        self.assertIn(
+            ProtoMessageRemoved(
+                ProtoMessage(None, ProtoIdentifier(None, "BazMessage"), [])
             ),
             diff,
         )
@@ -1062,25 +1062,25 @@ class MessageTest(unittest.TestCase):
         diff = ProtoMessage.diff_sets(set1, set2)
         self.assertIn(
             ProtoMessageAdded(
-                ProtoMessage(None, ProtoIdentifier(None, "FooMessage"), [])
-            ),
-            diff,
-        )
-        self.assertIn(
-            ProtoMessageAdded(
-                ProtoMessage(None, ProtoIdentifier(None, "BazMessage"), [])
-            ),
-            diff,
-        )
-        self.assertIn(
-            ProtoMessageRemoved(
                 ProtoMessage(None, ProtoIdentifier(None, "FooMessage2"), [])
             ),
             diff,
         )
         self.assertIn(
-            ProtoMessageRemoved(
+            ProtoMessageAdded(
                 ProtoMessage(None, ProtoIdentifier(None, "BazMessage2"), [])
+            ),
+            diff,
+        )
+        self.assertIn(
+            ProtoMessageRemoved(
+                ProtoMessage(None, ProtoIdentifier(None, "FooMessage"), [])
+            ),
+            diff,
+        )
+        self.assertIn(
+            ProtoMessageRemoved(
+                ProtoMessage(None, ProtoIdentifier(None, "BazMessage"), [])
             ),
             diff,
         )

--- a/test/proto_option_test.py
+++ b/test/proto_option_test.py
@@ -328,8 +328,7 @@ class OptionTest(unittest.TestCase):
         self.assertEqual(ProtoOption.diff_sets(set1, set1), [])
 
     def test_diff_sets_all_removed(self):
-        set1 = []
-        set2 = [
+        set1 = [
             ProtoOption(
                 None,
                 ProtoIdentifier(None, "some.custom.option"),
@@ -346,6 +345,7 @@ class OptionTest(unittest.TestCase):
                 ProtoConstant(None, ProtoInt(None, 100, ProtoIntSign.POSITIVE)),
             ),
         ]
+        set2 = []
         diff = ProtoOption.diff_sets(set1, set2)
 
         self.assertIn(
@@ -381,7 +381,8 @@ class OptionTest(unittest.TestCase):
         self.assertEqual(3, len(diff))
 
     def test_diff_sets_all_added(self):
-        set1 = [
+        set1 = []
+        set2 = [
             ProtoOption(
                 None,
                 ProtoIdentifier(None, "some.custom.option"),
@@ -398,7 +399,6 @@ class OptionTest(unittest.TestCase):
                 ProtoConstant(None, ProtoInt(None, 100, ProtoIntSign.POSITIVE)),
             ),
         ]
-        set2 = []
         diff = ProtoOption.diff_sets(set1, set2)
 
         self.assertIn(
@@ -437,23 +437,6 @@ class OptionTest(unittest.TestCase):
         set1 = [
             ProtoOption(
                 None,
-                ProtoIdentifier(None, "some.custom.option.but.not.prior"),
-                ProtoConstant(None, ProtoStringLiteral(None, "some value")),
-            ),
-            ProtoOption(
-                None,
-                ProtoIdentifier(None, "ruby_package"),
-                ProtoConstant(None, ProtoStringLiteral(None, "foo.bar.baz")),
-            ),
-            ProtoOption(
-                None,
-                ProtoIdentifier(None, "other.option.but.stil.not.prior"),
-                ProtoConstant(None, ProtoInt(None, 100, ProtoIntSign.POSITIVE)),
-            ),
-        ]
-        set2 = [
-            ProtoOption(
-                None,
                 ProtoIdentifier(None, "some.custom.option"),
                 ProtoConstant(None, ProtoStringLiteral(None, "some value")),
             ),
@@ -465,6 +448,23 @@ class OptionTest(unittest.TestCase):
             ProtoOption(
                 None,
                 ProtoIdentifier(None, "other.option"),
+                ProtoConstant(None, ProtoInt(None, 100, ProtoIntSign.POSITIVE)),
+            ),
+        ]
+        set2 = [
+            ProtoOption(
+                None,
+                ProtoIdentifier(None, "some.custom.option.but.not.prior"),
+                ProtoConstant(None, ProtoStringLiteral(None, "some value")),
+            ),
+            ProtoOption(
+                None,
+                ProtoIdentifier(None, "ruby_package"),
+                ProtoConstant(None, ProtoStringLiteral(None, "foo.bar.baz")),
+            ),
+            ProtoOption(
+                None,
+                ProtoIdentifier(None, "other.option.but.stil.not.prior"),
                 ProtoConstant(None, ProtoInt(None, 100, ProtoIntSign.POSITIVE)),
             ),
         ]
@@ -542,23 +542,6 @@ class OptionTest(unittest.TestCase):
         set1 = [
             ProtoOption(
                 None,
-                ProtoIdentifier(None, "some.custom.option.but.not.prior"),
-                ProtoConstant(None, ProtoStringLiteral(None, "some value")),
-            ),
-            ProtoOption(
-                None,
-                ProtoIdentifier(None, "java_package"),
-                ProtoConstant(None, ProtoStringLiteral(None, "foo.bar.bat")),
-            ),
-            ProtoOption(
-                None,
-                ProtoIdentifier(None, "other.option.but.stil.not.prior"),
-                ProtoConstant(None, ProtoInt(None, 100, ProtoIntSign.POSITIVE)),
-            ),
-        ]
-        set2 = [
-            ProtoOption(
-                None,
                 ProtoIdentifier(None, "some.custom.option"),
                 ProtoConstant(None, ProtoStringLiteral(None, "some value")),
             ),
@@ -570,6 +553,23 @@ class OptionTest(unittest.TestCase):
             ProtoOption(
                 None,
                 ProtoIdentifier(None, "other.option"),
+                ProtoConstant(None, ProtoInt(None, 100, ProtoIntSign.POSITIVE)),
+            ),
+        ]
+        set2 = [
+            ProtoOption(
+                None,
+                ProtoIdentifier(None, "some.custom.option.but.not.prior"),
+                ProtoConstant(None, ProtoStringLiteral(None, "some value")),
+            ),
+            ProtoOption(
+                None,
+                ProtoIdentifier(None, "java_package"),
+                ProtoConstant(None, ProtoStringLiteral(None, "foo.bar.bat")),
+            ),
+            ProtoOption(
+                None,
+                ProtoIdentifier(None, "other.option.but.stil.not.prior"),
                 ProtoConstant(None, ProtoInt(None, 100, ProtoIntSign.POSITIVE)),
             ),
         ]
@@ -620,8 +620,8 @@ class OptionTest(unittest.TestCase):
         self.assertIn(
             ProtoOptionValueChanged(
                 ProtoIdentifier(None, "java_package"),
-                ProtoConstant(None, ProtoStringLiteral(None, "foo.bar.bat")),
                 ProtoConstant(None, ProtoStringLiteral(None, "foo.bar.baz")),
+                ProtoConstant(None, ProtoStringLiteral(None, "foo.bar.bat")),
             ),
             diff,
         )

--- a/test/proto_package_test.py
+++ b/test/proto_package_test.py
@@ -82,23 +82,23 @@ class PackageTest(unittest.TestCase):
         )
 
     def test_diff_package_added(self):
-        pp1 = ProtoPackage(None, "my.new.package")
-        pp2 = None
+        pp1 = None
+        pp2 = ProtoPackage(None, "my.new.package")
         self.assertEqual(
-            ProtoPackage.diff(pp1, pp2),
             [
                 ProtoPackageAdded(ProtoPackage(None, "my.new.package")),
             ],
+            ProtoPackage.diff(pp1, pp2),
         )
 
     def test_diff_package_removed(self):
-        pp1 = None
-        pp2 = ProtoPackage(None, "my.old.package")
+        pp1 = ProtoPackage(None, "my.old.package")
+        pp2 = None
         self.assertEqual(
-            ProtoPackage.diff(pp1, pp2),
             [
                 ProtoPackageRemoved(ProtoPackage(None, "my.old.package")),
             ],
+            ProtoPackage.diff(pp1, pp2),
         )
 
 

--- a/test/util/compatibility_checker_binary_test.sh
+++ b/test/util/compatibility_checker_binary_test.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-./src/util/compatibility_checker_binary ./test/resources/single_message.proto ./test/resources/empty.proto
+./src/util/compatibility_checker_binary ./test/resources/empty.proto ./test/resources/single_message.proto


### PR DESCRIPTION
- Change semantics around enum value diffs: we no longer support "value has changed number" diffs. Instead, we emit one EnumValueRemoved at the prior number, and one EnumValueAdded at the new number.
- Follow same semantics for message field diffs
- We used to pass left/right into diff methods. To make the meaning unambiguous, we change this to before/after, and correct a _ton_ of places we were using this inconsistently.